### PR TITLE
Bump jquery dependency from 2.0.x to 2.1.x

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "lanejs",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "homepage": "https://github.com/dawanda/lanejs",
   "authors": [
     "DaWanda GmbH"
@@ -21,7 +21,7 @@
     "tests"
   ],
   "dependencies": {
-    "jquery": "2.0.x",
+    "jquery": "2.1.x",
     "lodash": "2.x.x",
     "moment": "2.7.x",
     "cartograph": "0.1.x",


### PR DESCRIPTION
to meet requirements for new version of tagsinput.
