### PR TITLE
Let StatefulWidget throw an error when using the selector failed

### DIFF
--- a/src/stateful_widget.js.coffee
+++ b/src/stateful_widget.js.coffee
@@ -52,6 +52,7 @@ namespace "Lib.StatefulWidget", ->
     constructor: ( selector ) ->
       @_uid ?= @_generateUID()
       @$el = $( selector )
+      throw new Error "Unable to select DOM element with selector '#{selector}'" unless @$el.length
       @el = @$el[0]
       @initState @_states[0] if @_states?[0]?
       @_bindEvents()


### PR DESCRIPTION
Since StatefulWidget can't do much without having found a DOM element upon instantiation, it would make debugging easier to let it throw an explicit error when the passed selector didn't work.
