### PR TITLE
Turned exception into warning so lanejs users can adapt

### DIFF
--- a/src/stateful_widget.js.coffee
+++ b/src/stateful_widget.js.coffee
@@ -52,7 +52,8 @@ namespace "Lib.StatefulWidget", ->
     constructor: ( selector ) ->
       @_uid ?= @_generateUID()
       @$el = $( selector )
-      throw new Error "Unable to select DOM element with selector '#{selector}'" unless @$el.length
+      if console?.warn? and @$el.length is 0
+        console.warn "No DOM elements found with selector '#{selector}'"
       @el = @$el[0]
       @initState @_states[0] if @_states?[0]?
       @_bindEvents()


### PR DESCRIPTION
Lanejs users should not suddenly have an exception breaking existing code that might use the stateful widget in unintended ways. For the case when the selector passed to the constructor doesn't result in DOM nodes, we only show a warning for now.
