### PR TITLE
Bug with Range Validator :: min and max as functions are not handled properly

### DIFF
--- a/spec/validators_spec.coffee
+++ b/spec/validators_spec.coffee
@@ -177,6 +177,30 @@ describe "Lib.Validators", ->
       fv.validate @model
       expect( @model.addError ).toHaveBeenCalledWith "foo", "not in_range"
 
+    it "adds a validation that has min and max as functions", ->
+      minFunc = -> 0.5 * @get("bar")
+      maxFunc = -> 2 * @get("bar")
+      foobar = { bar: 10, foo: 15 }
+      fv = new @V.RangeValidator "foo", min: minFunc, max: maxFunc
+      spyOn @model, "addError"
+      spyOn(@model, "get").and.callFake ( attr ) ->
+        foobar[attr]
+      fv.validate @model
+      expect( @model.addError ).not.toHaveBeenCalled()
+
+    it "adds a validation that has min and max as functions and handles attribute dependent functions properly", ->
+      minFunc = -> 0.5 * @get("bar")
+      maxFunc = -> 2 * @get("bar")
+      foobar = { bar: 10, foo: 15 }
+      fv = new @V.RangeValidator "foo", min: minFunc, max: maxFunc
+      spyOn @model, "addError"
+      spyOn(@model, "get").and.callFake ( attr ) ->
+        foobar[attr]
+      fv.validate @model
+      foobar.bar = 2
+      fv.validate @model
+      expect( @model.addError ).toHaveBeenCalledWith "foo", "not in_range"
+
   describe "AcceptanceValidator", ->
 
     it "adds no errors if the attribute has the acceptance value", ->

--- a/src/validators.js.coffee
+++ b/src/validators.js.coffee
@@ -68,15 +68,17 @@ class RangeValidator extends BaseValidator
   constructor: ( attr, opts ) ->
     super attr, opts
     @attribute = attr
+    @options.minFunc = @options.min if @options.min? and typeof @options.min is "function"
+    @options.maxFunc = @options.max if @options.max? and typeof @options.max is "function"
     @options.message ?= I18n.t("errors.messages.not_in_range")
 
   run: ( obj ) ->
     value = obj.get @attribute
     return unless value? and ( value + "" ).length > 0 and (@options.max? or @options.min?)
-    if @options.min? and typeof @options.min is "function"
-      @options.min = @options.min.call( obj )
-    if @options.max? and typeof @options.max is "function"
-      @options.max = @options.max.call( obj )
+    if @options.minFunc?
+      @options.min = @options.minFunc.call( obj )
+    if @options.maxFunc?
+      @options.max = @options.maxFunc.call( obj )
 
     if @options.min? and typeof @options.min is "object" and @options.min._isAMomentObject and !value.min(@options.min)
       obj.addError @attribute, @options.message


### PR DESCRIPTION
With `RangeValidator` one can use functions in place of values for `min` and `max` options. Like this:

```coffee
  validates "foo", range:
    min: -> 0.5 * @get "bar"
    max: -> 2 * @get "bar"
```

When you run validation first time on it, it will replace `@options.min` and `@options.max` with respective values returned from functions. And after that these functions will never be called again. Even on different instances of model.

This PR fixes it by copying `min` and `max` functions to `@options.minFunc` and `@options.maxFunc` when they are functions. And uses these options to call on target object and writes return value to `@options.min` and `@options.max` respectively.
