### PR TITLE
Remove warning about empty element

### DIFF
--- a/src/stateful_widget.js.coffee
+++ b/src/stateful_widget.js.coffee
@@ -52,8 +52,6 @@ namespace "Lib.StatefulWidget", ->
     constructor: ( selector ) ->
       @_uid ?= @_generateUID()
       @$el = $( selector )
-      if console?.warn? and @$el.length is 0
-        console.warn "No DOM elements found with selector '#{selector}'"
       @el = @$el[0]
       @initState @_states[0] if @_states?[0]?
       @_bindEvents()


### PR DESCRIPTION
I added a warning to the constructor of Lib.StatefulWidget with the idea that these should always be constructed with an existing DOM element. As it turns out there are many places in our code where we don't pass a valid selector, and this seems to be common practice. Given this, displaying the warning is more of an annoyance and I took it out again.